### PR TITLE
fix jump judgement

### DIFF
--- a/Assets/Player/PlayerBehavior.cs
+++ b/Assets/Player/PlayerBehavior.cs
@@ -7,7 +7,7 @@ public class PlayerBehavior : MonoBehaviour
     public float moveSpeed = 5f;     // 水平方向の移動速度
     public float jumpForce = 7f;     // ジャンプ力
     private Rigidbody2D rb;          // 2D物理演算用リジッドボディ
-    private bool isGrounded = false; // 地面についているかの判定
+    private bool isGrounded; // 地面についているかの判定
     float rayLength = 0.1f;
     RaycastHit2D hit;
 
@@ -16,10 +16,12 @@ public class PlayerBehavior : MonoBehaviour
     {
         // Rigidbody2Dを取得
         rb = GetComponent<Rigidbody2D>();
+        isGrounded = false;
     }
 
     void Update()
     {
+        Debug.Log(isGrounded);
         // --- 左右移動 ---
         float move = 0f;
 
@@ -35,6 +37,7 @@ public class PlayerBehavior : MonoBehaviour
         // Rigidbody2D の速度を直接変更（Time.deltaTimeは不要）
         rb.velocity = new Vector2(move * moveSpeed, rb.velocity.y);
 
+
         // --- ジャンプ ---
         if (Input.GetKeyDown(KeyCode.W) && isGrounded)
         {
@@ -46,12 +49,13 @@ public class PlayerBehavior : MonoBehaviour
     // --- 地面に接触したとき ---
     void OnCollisionEnter2D(Collision2D collision)
     {
-        foreach (ContactPoint2D contact in collision.contacts){
-            if (collision.gameObject != null && (contact.point.y < transform.position.y - rayLength))
+
+        Debug.Log(collision.gameObject.CompareTag("Ground"));
+
+        if (collision.gameObject.CompareTag("Ground"))
         {
-            Debug.Log("Grounded");
             isGrounded = true;
-        }
+            Debug.Log("Ground判定");
         }
     }
 }

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -134,6 +134,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Step (6)
       objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
       value: 33.504734
@@ -190,6 +194,10 @@ PrefabInstance:
     - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_Name
       value: Step (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
       objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
@@ -501,6 +509,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Step (8)
       objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
       value: 43.8486
@@ -559,7 +571,7 @@ GameObject:
   - component: {fileID: 805024989}
   m_Layer: 0
   m_Name: Plane
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -790,6 +802,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Step (9)
       objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
       value: 48.56623
@@ -846,6 +862,10 @@ PrefabInstance:
     - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_Name
       value: Step (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
       objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
@@ -904,6 +924,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Step (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
       value: 21.623285
@@ -960,6 +984,10 @@ PrefabInstance:
     - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_Name
       value: Step (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
       objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1018,6 +1046,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Step (7)
       objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
       value: 39.096016
@@ -1074,6 +1106,10 @@ PrefabInstance:
     - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_Name
       value: Step (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
       objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1333,7 +1369,7 @@ Transform:
   m_GameObject: {fileID: 2005212715}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -7.19, y: -3.65, z: 0}
+  m_LocalPosition: {x: -7.103, y: -3.498, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1528,6 +1564,10 @@ PrefabInstance:
     - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_Name
       value: Step
+      objectReference: {fileID: 0}
+    - target: {fileID: 429260252514005652, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
+      propertyPath: m_TagString
+      value: Ground
       objectReference: {fileID: 0}
     - target: {fileID: 1662096111114502088, guid: e6086adb68a732744a5e5154b204ceec, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Step.prefab
+++ b/Assets/Step.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 1490125995708754958}
   m_Layer: 0
   m_Name: Step
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -28,7 +28,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.14, y: -2.19, z: 0}
-  m_LocalScale: {x: 4.3198, y: 0.5108, z: 1}
+  m_LocalScale: {x: 4.1143603, y: 0.5108, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,9 @@ TagManager:
   serializedVersion: 2
   tags:
   - Plane
+  - Undefined
+  - Step
+  - Ground
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
playerオブジェクトにアタッチしているスクリプトを書き換えた。foreachで他のオブジェクトに触れている点の配列を取り出して判定していたが、地面をGroundというタグで判定するようにして、タグによりジャンプできるように判定をつかさどる変数を変更するようにした。